### PR TITLE
Implementation InFilter and NotFilter Converters

### DIFF
--- a/src/test/kotlin/com/github/vokorm/FiltersTest.kt
+++ b/src/test/kotlin/com/github/vokorm/FiltersTest.kt
@@ -34,6 +34,15 @@ class FiltersTest : DynaTest({
         }
 
         group("filter test") {
+            test("not filter test") {
+                Person(name = "Moby", age = 25).create()
+                Person(name = "Jerry", age = 26).create()
+                Person(name = "Paul", age = 27).create()
+                expectList("Moby", "Paul") {
+                    Person.findAllBy { !(Person::age eq 26) }.map { it.name }
+                }
+            }
+
             test("in filter test") {
                 Person(name = "Moby", age = 25).create()
                 Person(name = "Jerry", age = 26).create()


### PR DESCRIPTION
Implementations for InFilter and NotFilter SQL-Converters. https://github.com/mvysny/vok-orm/issues/15#
I could not get jdbi to map e.g. an Array automatically onto a parameter so I had to split the list into multiple parameters for the InFilter.

Maybe an interesting sidenote: jdbi supports resolving arrays with named parameters like `(<parameter>)`, which can be bound with `bindList`, this didn't work with vok-orm however.